### PR TITLE
Fjerne dependency som brukes for unleash

### DIFF
--- a/.github/workflows/deploy-feature-branch.yml
+++ b/.github/workflows/deploy-feature-branch.yml
@@ -4,6 +4,9 @@ run-name: Deploy feature branch ${{ github.ref_name }} by @${{ github.actor }}
 on:
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: write
 env:
   IMAGE_TAG: ${{ github.sha }}
   IMAGE: ghcr.io/${{ github.repository }}/veilarbvedtakinfo

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
         <!-- felles bibliotek -->
         <dependency>
             <groupId>com.github.navikt.common-java-modules</groupId>
-            <artifactId>feature-toggle</artifactId>
-            <version>${common.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.navikt.common-java-modules</groupId>
             <artifactId>util</artifactId>
             <version>${common.version}</version>
         </dependency>


### PR DESCRIPTION
Kan ikke se at det er noen brytere eller bruk av unleash, så ikke noe å migrere til unleash-next. Man har tatt inn common-java-modules sin feature-toggle pakke som en avhengighet så jeg fjerner den så man ikke tar i bruk gammel uleash dersom man skal legge til en bryter i fremtiden